### PR TITLE
Improvments

### DIFF
--- a/actions/market/change_cover.php
+++ b/actions/market/change_cover.php
@@ -1,0 +1,18 @@
+<?php 
+
+$guid = get_input('guid');
+$image = get_entity($guid);
+
+if (!$image instanceof ElggFile || !$image->canEdit()) {
+	register_error(elgg_echo('market:image:invalid'));
+}
+
+$entity = get_entity($image->container_guid);
+
+$entity->cover_img = $image->guid;
+if($entity->save()){
+  system_message('market:icon:upload:update');
+}
+
+forward(REFERRER);
+ ?>

--- a/actions/market/del_img.php
+++ b/actions/market/del_img.php
@@ -1,0 +1,35 @@
+<?php 
+
+$guid = get_input('guid');
+
+$image = get_entity($guid);
+
+if (!$image instanceof ElggFile || !$image->canEdit()) {
+	register_error(elgg_echo('market:image:invalid'));
+}
+
+$entity = get_entity($image->container_guid);
+
+if($image->delete()){
+  remove_entity_relationship($image->guid, 'attached', $entity->guid);
+  system_message(elgg_echo('market:image:deleted'));
+}
+
+// if the deleted image is the cover image then replace the image
+if($entity->cover_img == $guid){
+  $options = [
+  	'relationship' => 'attached',
+  	'relationship_guid' => $entity->guid,
+  	'inverse_relationship' => true,
+  	'metadata_name_value_pairs' => [
+  		'name' => 'simpletype', 'value' => 'image',
+  	],
+  	'limit' => 1,
+  ];
+  $images = elgg_get_entities($options);
+  $entity->cover_img = $images[0]->guid;
+  $entity->save();
+}
+
+forward(REFERRER);
+ ?>

--- a/actions/market/save.php
+++ b/actions/market/save.php
@@ -107,7 +107,8 @@ if ($upload_guids) {
 			continue;
 		}
 		$upload->origin = 'market';
-		$upload->container_guid = $user->guid;
+		$upload->owner_guid = $user->guid;
+		$upload->container_guid = $post->guid;
 		$upload->access_id = $post->access_id;
 		if ($upload->save()) {
 			$uploads[] = $upload;

--- a/actions/market/save.php
+++ b/actions/market/save.php
@@ -95,9 +95,11 @@ if (!$post->save()) {
 }
 
 // handle icon upload
-$post->saveIconFromUploadedFile('icon');
-
 $upload_guids = (array) get_input('upload_guids', []);
+if($post->cover_img == null){
+	$post->cover_img = $upload_guids[0];
+}
+
 if ($upload_guids) {
 	foreach ($upload_guids as $upload_guid) {
 		$upload = get_entity($upload_guid);

--- a/elgg-plugin.php
+++ b/elgg-plugin.php
@@ -23,6 +23,7 @@ return [
 		'market/sold' => [],
 		'market/open' => [],
 		'market/save' => [],
+		'market/del_img' => [],
 	],
 	'routes' => [
 		'default:object:market' => [

--- a/elgg-plugin.php
+++ b/elgg-plugin.php
@@ -24,6 +24,7 @@ return [
 		'market/open' => [],
 		'market/save' => [],
 		'market/del_img' => [],
+		'market/change_cover' => [],
 	],
 	'routes' => [
 		'default:object:market' => [

--- a/languages/en.php
+++ b/languages/en.php
@@ -98,6 +98,7 @@ View the Market ad here: %s
 	'market:deleted' => "Your Market ad was successfully deleted.",
 	'market:uploaded' => "Your image was succesfully added.",
 	'market:image:deleted' => "Your image was succesfully deleted.",
+	'market:image:invalid' => "Not a valid market image file.",
 	'market:status:sold' => 'The item has been marked as sold by the owner',
 
 	// Error messages	

--- a/languages/en.php
+++ b/languages/en.php
@@ -31,6 +31,7 @@ return [
 	'market:everyone' => "All ads",
 	'item:object:market' => 'Market ad',
 	'market:none:found' => 'No market ad found',
+	'market:cover:update:text' => 'Update Cover',
 	
 	'add:object:market' => "Create new ad",
 	'market:read' => "View ad",
@@ -46,6 +47,7 @@ return [
 	'market:action:sold' => "Item marked as sold",
 	
 	'market:icon:upload:new' => "Add cover icon to your ad",
+	'market:icon:upload:update' => "Cover icon updated for your ad",
 	'market:icon:upload:edit' => "Edit cover icon of your ad",
 	'market:uploadimages' => "Add images to your ad.",
 	

--- a/views/default/forms/market/save.php
+++ b/views/default/forms/market/save.php
@@ -202,7 +202,7 @@ if(count((array)$images) > 0){
 		]);
 		
 		$del_href = elgg_generate_action_url('market/del_img',['guid' => $image->guid]);
-		
+		$update_cover = elgg_generate_action_url('market/change_cover',['guid' => $image->guid]);
 		echo 
 		'	<div class="elgg-dropzone-item-props">
 				<div class="elgg-dropzone-thumbnail">'.$icon_view.'</div>
@@ -211,6 +211,7 @@ if(count((array)$images) > 0){
 				</div>
 				<div class="elgg-dropzone-controls">
 					<a href="'.$del_href.'" class="elgg-dropzone-remove-icon" title="Remove" data-dz-remove=""><span class="elgg-icon elgg-icon-trash far fa-trash-alt"></span></a>
+					<a href="'.$update_cover.'" class="elgg-dropzone-remove-icon" title="Update Cover" data-dz-remove=""><span class="elgg-icon elgg-icon-file far fa-file-image-o"></a>
 				</div>
 			</div>';
 	}

--- a/views/default/forms/market/save.php
+++ b/views/default/forms/market/save.php
@@ -161,29 +161,6 @@ if (elgg_get_plugin_setting('market_comments', 'market') == 1) {
 	]);
 }
 
-//cover
-$icon_input = '';
-if ($post) {
-	$icon_label = elgg_echo('market:icon:upload:edit');
-	
-	if ($post->icontime) {
-		$icon_input = elgg_format_element('p', [], elgg_view('output/img', [
-			'src' => $post->getIconURL(),
-		]));
-	}
-} else {
-	$icon_label = elgg_echo('market:icon:upload:new');
-}
-
-echo elgg_view_field([
-	'#label' => $icon_label,
-	'#type' => 'file',
-	'name' => 'icon',
-	'id' => 'market_icon',
-	'accept' => 'image/*',
-	'#help' => $icon_input,
-]);
-
 //attached images
 echo elgg_view_field([
 	'#label' => elgg_echo('market:upload'),

--- a/views/default/forms/market/save.php
+++ b/views/default/forms/market/save.php
@@ -174,6 +174,49 @@ echo elgg_view_field([
 	'container_guid' => elgg_get_logged_in_user_guid(),
 ]);
 
+// Option to delete uploded image
+$options = [
+	'relationship' => 'attached',
+	'relationship_guid' => $entity->guid,
+	'inverse_relationship' => true,
+	'metadata_name_value_pairs' => [
+		'name' => 'simpletype', 'value' => 'image',
+	],
+	'limit' => 0,
+];
+$images = elgg_get_entities($options);
+if(count((array)$images) > 0){
+	echo '<div class="elgg-dropzone-preview dz-processing dz-image-preview dz-success dz-complete elgg-dropzone-success">'; 
+	foreach ($images as $image) {
+		$image_params = [
+			'alt' => $image->getDisplayName(),
+			'src' => $image->getIconURL(['size' => 'tiny']),
+			'class' => 'elgg-photo',
+		];
+		$icon = elgg_view('output/img', $image_params);
+		$icon_view = elgg_view('output/url', [
+			'text' => $icon,
+			'href' => $image->getIconURL('large'),
+			'class' => 'elgg-lightbox-photo',
+			'rel' => 'market-gallery',
+		]);
+		
+		$del_href = elgg_generate_action_url('market/del_img',['guid' => $image->guid]);
+		
+		echo 
+		'	<div class="elgg-dropzone-item-props">
+				<div class="elgg-dropzone-thumbnail">'.$icon_view.'</div>
+				<div class="elgg-dropzone-filename">
+					<span class="elgg-dropzone-filename-str" data-dz-name="">'.$image->getDisplayName().'</span>
+				</div>
+				<div class="elgg-dropzone-controls">
+					<a href="'.$del_href.'" class="elgg-dropzone-remove-icon" title="Remove" data-dz-remove=""><span class="elgg-icon elgg-icon-trash far fa-trash-alt"></span></a>
+				</div>
+			</div>';
+	}
+	echo '</div>';
+}
+
 //access level
 echo elgg_view_field([
 	'#label' => elgg_echo('access'),

--- a/views/default/forms/market/save.php
+++ b/views/default/forms/market/save.php
@@ -175,47 +175,49 @@ echo elgg_view_field([
 ]);
 
 // Option to delete uploded image
-$options = [
-	'relationship' => 'attached',
-	'relationship_guid' => $entity->guid,
-	'inverse_relationship' => true,
-	'metadata_name_value_pairs' => [
-		'name' => 'simpletype', 'value' => 'image',
-	],
-	'limit' => 0,
-];
-$images = elgg_get_entities($options);
-if(count((array)$images) > 0){
-	echo '<div class="elgg-dropzone-preview dz-processing dz-image-preview dz-success dz-complete elgg-dropzone-success">'; 
-	foreach ($images as $image) {
-		$image_params = [
-			'alt' => $image->getDisplayName(),
-			'src' => $image->getIconURL(['size' => 'tiny']),
-			'class' => 'elgg-photo',
-		];
-		$icon = elgg_view('output/img', $image_params);
-		$icon_view = elgg_view('output/url', [
-			'text' => $icon,
-			'href' => $image->getIconURL('large'),
-			'class' => 'elgg-lightbox-photo',
-			'rel' => 'market-gallery',
-		]);
-		
-		$del_href = elgg_generate_action_url('market/del_img',['guid' => $image->guid]);
-		$update_cover = elgg_generate_action_url('market/change_cover',['guid' => $image->guid]);
-		echo 
-		'	<div class="elgg-dropzone-item-props">
-				<div class="elgg-dropzone-thumbnail">'.$icon_view.'</div>
-				<div class="elgg-dropzone-filename">
-					<span class="elgg-dropzone-filename-str" data-dz-name="">'.$image->getDisplayName().'</span>
-				</div>
-				<div class="elgg-dropzone-controls">
-					<a href="'.$del_href.'" class="elgg-dropzone-remove-icon" title="Remove" data-dz-remove=""><span class="elgg-icon elgg-icon-trash far fa-trash-alt"></span></a>
-					<a href="'.$update_cover.'" class="elgg-dropzone-remove-icon" title="Update Cover" data-dz-remove=""><span class="elgg-icon elgg-icon-file far fa-file-image-o"></a>
-				</div>
-			</div>';
+if($post instanceof ElggMarket){
+	$options = [
+		'relationship' => 'attached',
+		'relationship_guid' => $post->guid,
+		'inverse_relationship' => true,
+		'metadata_name_value_pairs' => [
+			'name' => 'simpletype', 'value' => 'image',
+		],
+		'limit' => 0,
+	];
+	$images = elgg_get_entities($options);
+	if(count((array)$images) > 0){
+		echo '<div class="elgg-dropzone-preview dz-processing dz-image-preview dz-success dz-complete elgg-dropzone-success">'; 
+		foreach ($images as $image) {
+			$image_params = [
+				'alt' => $image->getDisplayName(),
+				'src' => $image->getIconURL(['size' => 'tiny']),
+				'class' => 'elgg-photo',
+			];
+			$icon = elgg_view('output/img', $image_params);
+			$icon_view = elgg_view('output/url', [
+				'text' => $icon,
+				'href' => $image->getIconURL('large'),
+				'class' => 'elgg-lightbox-photo',
+				'rel' => 'market-gallery',
+			]);
+			
+			$del_href = elgg_generate_action_url('market/del_img',['guid' => $image->guid]);
+			$update_cover = elgg_generate_action_url('market/change_cover',['guid' => $image->guid]);
+			echo 
+			'	<div class="elgg-dropzone-item-props">
+					<div class="elgg-dropzone-thumbnail">'.$icon_view.'</div>
+					<div class="elgg-dropzone-filename">
+						<span class="elgg-dropzone-filename-str" data-dz-name="">'.$image->getDisplayName().'</span>
+					</div>
+					<div class="elgg-dropzone-controls">
+						<a href="'.$del_href.'" class="elgg-dropzone-remove-icon" title="Remove" data-dz-remove=""><span class="elgg-icon elgg-icon-trash far fa-trash-alt"></span></a>
+						<a href="'.$update_cover.'" class="elgg-dropzone-remove-icon" title="Update Cover" data-dz-remove=""><span class="elgg-icon elgg-icon-file far fa-file-image-o"></a>
+					</div>
+				</div>';
+		}
+		echo '</div>';
 	}
-	echo '</div>';
 }
 
 //access level

--- a/views/default/object/market/meta.php
+++ b/views/default/object/market/meta.php
@@ -15,15 +15,20 @@ if (!$entity instanceof \ElggMarket) {
 }
 
 //cover icon
+if($entity->cover_img == null){
+	$cov_img = $entity;
+} else {
+	$cov_img = get_entity($entity->cover_img);
+}
 $image_params = [
 	'alt' => $entity->getDisplayName(),
-	'src' => $entity->getIconURL(['size' => 'medium']),
+	'src' => $cov_img->getIconURL(['size' => 'medium']),
 ];
 
 $image = elgg_view('output/img', $image_params);
 $cover_icon = elgg_view('output/url', [
 	'text' => $image,
-	'href' => $entity->getIconURL(['size' => 'large']),
+	'href' => $cov_img->getIconURL(['size' => 'large']),
 	'class' => 'elgg-lightbox-photo',
 ]);
 


### PR DESCRIPTION
Fix for https://github.com/RiverVanRain/market/issues/23
fix: Use one hypeDropzone for file upload 
fix: user can change cover icon from edit page
fix: show existing image div only in existing post

Fix for https://github.com/RiverVanRain/market/issues/22
fix: user can delete images directly from ad

Demo: Edit page with delete image and change cover buttons
![image](https://user-images.githubusercontent.com/2772844/56919444-3c644900-6ade-11e9-9887-03e7bd8d35f7.png)

